### PR TITLE
bundles es6 compatible code into the esm directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "three-usdz-loader",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "three-usdz-loader",
-      "version": "1.0.5",
+      "version": "1.0.7",
       "license": "Modified Apache 2.0",
       "dependencies": {
-        "three": "^0.141.0"
+        "three": "^0.143.0"
       },
       "devDependencies": {
         "@types/node": "^17.0.42",
-        "@types/three": "^0.141.0",
+        "@types/three": "^0.143.0",
         "@typescript-eslint/eslint-plugin": "^5.27.1",
         "@typescript-eslint/parser": "^5.27.1",
         "eslint": "^8.17.0",
@@ -164,9 +164,9 @@
       "dev": true
     },
     "node_modules/@types/three": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.141.0.tgz",
-      "integrity": "sha512-OJdKDgTPVBUgc+s74DYoy4aLznbFFC38Xm4ElmU1YwGNgR7GGFVvFCX7lpVgOsT6S1zSJtGdajTsOYE8/xY9nA==",
+      "version": "0.143.2",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.143.2.tgz",
+      "integrity": "sha512-HjsRWvd6rsXViFeOdU97/pHNDQknzJbFI0/5MrQ0joOlK0uixQH40sDJs/LwkNHhFYUvVENXAUQdKDeiQChHDw==",
       "dev": true,
       "dependencies": {
         "@types/webxr": "*"
@@ -1721,9 +1721,9 @@
       "dev": true
     },
     "node_modules/three": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.141.0.tgz",
-      "integrity": "sha512-JaSDAPWuk4RTzG5BYRQm8YZbERUxTfTDVouWgHMisS2to4E5fotMS9F2zPFNOIJyEFTTQDDKPpsgZVThKU3pXA=="
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.143.0.tgz",
+      "integrity": "sha512-oKcAGYHhJ46TGEuHjodo2n6TY2R6lbvrkp+feKZxqsUL/WkH7GKKaeu6RHeyb2Xjfk2dPLRKLsOP0KM2VgT8Zg=="
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -2004,9 +2004,9 @@
       "dev": true
     },
     "@types/three": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.141.0.tgz",
-      "integrity": "sha512-OJdKDgTPVBUgc+s74DYoy4aLznbFFC38Xm4ElmU1YwGNgR7GGFVvFCX7lpVgOsT6S1zSJtGdajTsOYE8/xY9nA==",
+      "version": "0.143.2",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.143.2.tgz",
+      "integrity": "sha512-HjsRWvd6rsXViFeOdU97/pHNDQknzJbFI0/5MrQ0joOlK0uixQH40sDJs/LwkNHhFYUvVENXAUQdKDeiQChHDw==",
       "dev": true,
       "requires": {
         "@types/webxr": "*"
@@ -3109,9 +3109,9 @@
       "dev": true
     },
     "three": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.141.0.tgz",
-      "integrity": "sha512-JaSDAPWuk4RTzG5BYRQm8YZbERUxTfTDVouWgHMisS2to4E5fotMS9F2zPFNOIJyEFTTQDDKPpsgZVThKU3pXA=="
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.143.0.tgz",
+      "integrity": "sha512-oKcAGYHhJ46TGEuHjodo2n6TY2R6lbvrkp+feKZxqsUL/WkH7GKKaeu6RHeyb2Xjfk2dPLRKLsOP0KM2VgT8Zg=="
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "A basic USDZ file (Pixar Universal Scene Description) loader for ThreeJS",
   "main": "lib/USDZLoader.js",
   "types": "lib/USDZLoader.d.ts",
+  "module": "lib/esm/USDZLoader.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc",
+    "build": "tsc && tsc --module es6 --outDir ./lib/esm",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.js\"",
     "lint": "tslint -p tsconfig.json"
   },
@@ -34,10 +35,10 @@
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^4.7.3",
-    "@types/three": "^0.141.0"
+    "@types/three": "^0.143.0"
   },
   "dependencies": {
-    "three": "^0.141.0"
+    "three": "^0.143.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# What?

I ran into an issue when bundling this app with an es6 app, my resulting packaged source included two threejs builds, `three.module.js` (from my original build) and `three.cjs` (this one is from this library). This is caused by the current version `1.0.7`.

This fixes duplicate builds by adding a separate build for `es6` in the `/lib/esm` directory and specifying the `module` entrypoint.

### Details
- Also upgrades three to `0.143.0` which is what I am using (is that ok?)
- Adds a build step that outputs `es6` compatible code in addition to `CommonJS`
- Adds the `module` property for the module code entrypoint `/lib/esm/USDZLoader.js`